### PR TITLE
perf: use debounce for vault event

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
         "@types/node": "^14.14.37",
         "@typescript-eslint/eslint-plugin": "^4.23.0",
         "@typescript-eslint/parser": "^4.23.0",
+        "assert-never": "^1.2.1",
         "cz-conventional-changelog": "^3.3.0",
         "eslint": "^7.26.0",
         "eslint-config-prettier": "^8.3.0",

--- a/src/misc.ts
+++ b/src/misc.ts
@@ -22,7 +22,8 @@ export const iterateItems = (
     }
 };
 
-export const getParentPath = (src: string) => {
+export const getParentPath = (src: string): string | null => {
+    if (src === '/') return null;
     const path = dirname(src);
     if (path === '.') return '/';
     else return path;
@@ -38,4 +39,12 @@ export const equals = (arr1: any, arr2: any) => {
     if (arr1.length != arr2.length) return false;
 
     return arr1.every((v, i) => v === arr2[i]);
+};
+
+export const isParent = (parent: string, child: string): boolean => {
+    if (child === parent) return false;
+    if (parent === '/') parent = '';
+    if (child === '/') child = '';
+    const parentTokens = parent.split('/').filter((i) => i.length);
+    return parentTokens.every((t, i) => child.split('/')[i] === t);
 };

--- a/src/vault-handler.ts
+++ b/src/vault-handler.ts
@@ -1,0 +1,38 @@
+import { updateCount } from 'folder-count';
+import FileExplorerNoteCount from 'main';
+import { getParentPath } from 'misc';
+import { App, debounce, TAbstractFile, Vault } from 'obsidian';
+
+export class VaultHandler {
+    waitingList: string[] = [];
+    get app(): App {
+        return this.plugin.app;
+    }
+    get vault(): Vault {
+        return this.plugin.app.vault;
+    }
+    plugin: FileExplorerNoteCount;
+    constructor(plugin: FileExplorerNoteCount) {
+        this.plugin = plugin;
+    }
+
+    update = debounce(
+        () => updateCount(this.waitingList, this.plugin),
+        500,
+        true,
+    );
+
+    handler = (...args: (string | TAbstractFile)[]) => {
+        for (const arg of args) {
+            const path = arg instanceof TAbstractFile ? arg.path : arg;
+            this.waitingList.push(getParentPath(path) ?? '/');
+        }
+        this.update();
+    };
+
+    registerVaultEvent = () => {
+        this.plugin.registerEvent(this.vault.on('create', this.handler));
+        this.plugin.registerEvent(this.vault.on('rename', this.handler));
+        this.plugin.registerEvent(this.vault.on('delete', this.handler));
+    };
+}


### PR DESCRIPTION
- now the returned path of all vault event is kept in waitingList and only get update when all
consecutive events are finished
- add filters to reduce duplicate count update